### PR TITLE
add amplify hosting

### DIFF
--- a/frontend/amplify/.config/project-config.json
+++ b/frontend/amplify/.config/project-config.json
@@ -1,5 +1,7 @@
 {
-  "providers": ["awscloudformation"],
+  "providers": [
+    "awscloudformation"
+  ],
   "projectName": "backend",
   "version": "3.1",
   "frontend": "javascript",
@@ -7,9 +9,10 @@
     "framework": "react",
     "config": {
       "SourceDir": "src",
-      "DistributionDir": "build",
+      "DistributionDir": "dist",
       "BuildCommand": "npm run-script build",
-      "StartCommand": "npm run-script start"
+      "StartCommand": "npm run-script start",
+      "ServerlessContainers": false
     }
   }
 }

--- a/frontend/amplify/backend/backend-config.json
+++ b/frontend/amplify/backend/backend-config.json
@@ -50,6 +50,13 @@
       "service": "Lambda"
     }
   },
+  "hosting": {
+    "amplifyhosting": {
+      "providerPlugin": "awscloudformation",
+      "service": "amplifyhosting",
+      "type": "manual"
+    }
+  },
   "parameters": {
     "AMPLIFY_function_api_deploymentBucketName": {
       "usedBy": [
@@ -64,6 +71,22 @@
         {
           "category": "function",
           "resourceName": "api"
+        }
+      ]
+    },
+    "AMPLIFY_hosting_amplifyhosting_appId": {
+      "usedBy": [
+        {
+          "category": "hosting",
+          "resourceName": "amplifyhosting"
+        }
+      ]
+    },
+    "AMPLIFY_hosting_amplifyhosting_type": {
+      "usedBy": [
+        {
+          "category": "hosting",
+          "resourceName": "amplifyhosting"
         }
       ]
     }

--- a/frontend/amplify/backend/hosting/amplifyhosting/amplifyhosting-template.json
+++ b/frontend/amplify/backend/hosting/amplifyhosting/amplifyhosting-template.json
@@ -1,0 +1,39 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "{\"createdOn\":\"Windows\",\"createdBy\":\"Amplify\",\"createdWith\":\"12.10.1\",\"stackType\":\"hosting-amplifyhosting\",\"metadata\":{}}",
+  "Parameters": {
+    "env": {
+      "Type": "String"
+    },
+    "appId": {
+      "Type": "String"
+    },
+    "type": {
+      "Type": "String"
+    }
+  },
+  "Conditions": {
+    "isManual": {
+      "Fn::Equals": [
+        {
+          "Ref": "type"
+        },
+        "manual"
+      ]
+    }
+  },
+  "Resources": {
+    "AmplifyBranch": {
+      "Condition": "isManual",
+      "Type": "AWS::Amplify::Branch",
+      "Properties": {
+        "BranchName": {
+          "Ref": "env"
+        },
+        "AppId": {
+          "Ref": "appId"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change is the result of the command `amplify add hosting`, alongside changing DistributionDir in project-config.json to be dist. With this change, manual deployment is possible via `amplify publish`. I'm unable to figure out how to modify the build settings used by `amplify publish`; thus `npm install` is necessary beforehand in order to create the build artifacts (online resources say to create an amplify.yml file in the project root directory, however when testing this didn't properly get consumed by `amplify publish`)

(The rest of this information is just bookkeeping, feel free to skip)
Note that this is for manual deployment only. Deploying full CI/CD is possible via connecting a Git provider to the Amplify console, however this runs into the issue that the amplifyconfiguration.json file is not generated prior to deployment. Since amplifyconfiguration.json defines infrastructure, this file should not be included in our repo according to IaC principles (normally this file is generated via `amplify init`, which provisions the necessary backend resources for the app). As such there seems to be some disconnect between the "building" and "hosting" aspects of Amplify. A workaround that I've found online is to have the user clone the repo, run amplify init/push, and then first push amplifyconfiguration.json to your Git provider prior to connecting the repo to the Amplify console. This can be included in the deployment guide.